### PR TITLE
Fix #5318: define version of discord_simple as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ yoyo-migrations==5.0.3
 paho-mqtt==1.2
 Geohash==1.0
 python-telegram-bot==5.0.0
-discord_simple>0.0.1.14
+discord_simple==0.0.1.15


### PR DESCRIPTION
## Short Description:
Change the version number of the discord_simple requirement to use the latest version available.

## Fixes/Resolves/Closes (please use correct syntax):
- #5318